### PR TITLE
Add missing handlers and defaults

### DIFF
--- a/roles/prometheus/handlers/main.yml
+++ b/roles/prometheus/handlers/main.yml
@@ -1,0 +1,39 @@
+---
+# Handlers for Prometheus role
+
+- name: reload systemd
+  systemd:
+    daemon_reload: yes
+  listen: "reload systemd"
+
+- name: restart prometheus
+  systemd:
+    name: prometheus
+    state: restarted
+    enabled: yes
+    daemon_reload: yes
+  listen: "restart prometheus"
+
+- name: restart powerdns-exporter
+  systemd:
+    name: powerdns-exporter
+    state: restarted
+    enabled: yes
+    daemon_reload: yes
+  listen: "restart powerdns-exporter"
+
+- name: restart node-exporter
+  systemd:
+    name: node-exporter
+    state: restarted
+    enabled: yes
+    daemon_reload: yes
+  listen: "restart node-exporter"
+
+- name: restart mysql-exporter
+  systemd:
+    name: mysql-exporter
+    state: restarted
+    enabled: yes
+    daemon_reload: yes
+  listen: "restart mysql-exporter"

--- a/roles/security_hardening/handlers/main.yml
+++ b/roles/security_hardening/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+# Handlers for security hardening role
+
+- name: reload apparmor
+  command: systemctl reload apparmor
+  listen: "reload apparmor"

--- a/roles/self_healing/handlers/main.yml
+++ b/roles/self_healing/handlers/main.yml
@@ -1,0 +1,39 @@
+---
+# Handlers for self_healing role
+
+- name: reload systemd
+  systemd:
+    daemon_reload: yes
+  listen: "reload systemd"
+
+- name: restart powerdns-watchdog
+  systemd:
+    name: powerdns-watchdog.service
+    state: restarted
+    enabled: yes
+    daemon_reload: yes
+  listen: "restart powerdns-watchdog"
+
+- name: start powerdns-watchdog-timer
+  systemd:
+    name: powerdns-watchdog.timer
+    state: started
+    enabled: yes
+    daemon_reload: yes
+  listen: "start powerdns-watchdog-timer"
+
+- name: restart mysql-watchdog
+  systemd:
+    name: mysql-watchdog.service
+    state: restarted
+    enabled: yes
+    daemon_reload: yes
+  listen: "restart mysql-watchdog"
+
+- name: start mysql-watchdog-timer
+  systemd:
+    name: mysql-watchdog.timer
+    state: started
+    enabled: yes
+    daemon_reload: yes
+  listen: "start mysql-watchdog-timer"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -156,6 +156,16 @@ clean_install_packages:
       - ipvsadm
 
 #################################
+# Feature Toggles
+#################################
+
+haproxy_enabled: false
+keepalived_enabled: false
+recursor_enabled: false
+prometheus_enabled: false
+self_healing_enabled: false
+
+#################################
 # HAProxy Configuration
 #################################
 


### PR DESCRIPTION
## Summary
- add missing handlers for self-healing watchdogs
- add Prometheus service handlers
- add AppArmor reload handler
- define feature toggle defaults

## Testing
- `ansible-playbook powerdns-playbook.yml --syntax-check`
- `ansible-playbook powerdns-operational-playbook.yml --syntax-check`
- `ansible-lint || true`

------
https://chatgpt.com/codex/tasks/task_e_687db44169fc8333a52a79abea99338a