### PR TITLE
Enhance audit script for clearer reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ private/
 # Logs
 logs/
 *.log.*
+
+# Audit outputs
+audit_output.yaml

--- a/audit_ansible.py
+++ b/audit_ansible.py
@@ -1,0 +1,253 @@
+"""Ansible collection audit helper.
+
+This script scans roles and playbooks from the repository root and
+generates a concise validation report in Markdown format.  It checks
+for required role subdirectories, placeholder content, undefined
+variables, and basic task metadata such as ``name`` and ``tags``.
+
+The resulting report is written to ``validation_report.md`` in the
+repository root.
+"""
+
+import os
+import re
+import glob
+from collections import defaultdict
+from typing import Dict, Iterable, List, Set
+
+import yaml
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+ROLE_SUBDIRS = [
+    "tasks",
+    "defaults",
+    "vars",
+    "handlers",
+    "templates",
+    "files",
+    "meta",
+]
+
+# Detect common placeholders or empty files.
+PLACEHOLDER_RE = re.compile(r"TODO|REPLACE_ME", re.IGNORECASE)
+# Capture Jinja variable usage.
+VAR_RE = re.compile(r"{{\s*([^\s{}]+)\s*}}")
+
+
+def find_roles(root: str) -> List[str]:
+    """Return a list of role directories."""
+
+    roles_path = os.path.join(root, "roles")
+    return [
+        os.path.join(roles_path, name)
+        for name in os.listdir(roles_path)
+        if os.path.isdir(os.path.join(roles_path, name))
+    ] if os.path.isdir(roles_path) else []
+
+
+def load_yaml(path: str):
+    """Load YAML data, returning ``None`` on failure."""
+
+    try:
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        return None
+
+
+def _extract_vars_from_string(content: str) -> Iterable[str]:
+    for var in VAR_RE.findall(content):
+        yield var.split("|")[0]
+
+
+def collect_vars(role_path: str) -> Set[str]:
+    """Collect all Jinja variables referenced in a role."""
+
+    found: Set[str] = set()
+    for sub in ["tasks", "handlers", "templates"]:
+        sub_path = os.path.join(role_path, sub)
+        if not os.path.isdir(sub_path):
+            continue
+        for root_dir, _, files in os.walk(sub_path):
+            for fname in files:
+                if fname.endswith((".yml", ".yaml", ".j2")):
+                    with open(os.path.join(root_dir, fname)) as f:
+                        found.update(_extract_vars_from_string(f.read()))
+    return found
+
+
+def check_role(role_path: str, defined_vars: Set[str]) -> Dict[str, List[str]]:
+    """Inspect a single role and return findings."""
+
+    findings: Dict[str, Set[str]] = defaultdict(set)
+
+    # Missing standard directories and meta file
+    for sub in ROLE_SUBDIRS:
+        if not os.path.isdir(os.path.join(role_path, sub)):
+            findings["missing"].add(f"{sub} directory")
+    if not os.path.isfile(os.path.join(role_path, "meta", "main.yml")):
+        findings["missing"].add("meta/main.yml")
+
+    # Collect handler names
+    handlers: Set[str] = set()
+    for hfile in glob.glob(os.path.join(role_path, "handlers", "*.yml")):
+        data = load_yaml(hfile)
+        if isinstance(data, list):
+            for task in data:
+                if isinstance(task, dict) and task.get("name"):
+                    handlers.add(task["name"])
+
+    # Validate tasks recursively and gather variables
+    used_vars = collect_vars(role_path)
+    missing_tags: Dict[str, List[str]] = defaultdict(list)
+    for root_dir, _, files in os.walk(os.path.join(role_path, "tasks")):
+        for fname in files:
+            if not fname.endswith(".yml"):
+                continue
+            tfile = os.path.join(root_dir, fname)
+            data = load_yaml(tfile)
+            if not isinstance(data, list):
+                findings["broken"].add(f"Invalid YAML: {tfile}")
+                continue
+            for task in data:
+                if not isinstance(task, dict):
+                    continue
+                if not task.get("name"):
+                    findings["broken"].add(f"{tfile} - missing task name")
+                if "tags" not in task:
+                    missing_tags[tfile].append(task.get("name", "unnamed"))
+                if "notify" in task:
+                    targets = task["notify"]
+                    if not isinstance(targets, list):
+                        targets = [targets]
+                    for trg in targets:
+                        if trg not in handlers:
+                            findings["broken"].add(
+                                f"{tfile} notifies undefined handler '{trg}'"
+                            )
+    for tfile, tasks in missing_tags.items():
+        findings["broken"].add(
+            f"{tfile} missing tags for: {', '.join(tasks)}"
+        )
+
+    # Detect placeholder content
+    for root_dir, _, files in os.walk(role_path):
+        for fname in files:
+            fpath = os.path.join(root_dir, fname)
+            with open(fpath, errors="ignore") as fh:
+                text = fh.read()
+                if PLACEHOLDER_RE.search(text) or not text.strip():
+                    findings["placeholders"].add(fpath)
+
+    # Undefined variables
+    undefined = used_vars - defined_vars
+    if undefined:
+        findings["undefined_vars"].update(sorted(undefined))
+
+    return {k: sorted(v) for k, v in findings.items()}
+
+
+def _gather_keys(obj) -> Set[str]:
+    keys: Set[str] = set()
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            keys.add(k)
+            keys.update(_gather_keys(v))
+    elif isinstance(obj, list):
+        for item in obj:
+            keys.update(_gather_keys(item))
+    return keys
+
+
+def load_all_defined_vars() -> Set[str]:
+    """Return a set of all defined variable names."""
+
+    defined: Set[str] = set()
+    # Root-level vars, inventory and group/host vars
+    var_files = glob.glob(os.path.join(ROOT_DIR, "vars", "*.yml"))
+    var_files += glob.glob(os.path.join(ROOT_DIR, "inventory", "*.yml"))
+    var_files += glob.glob(os.path.join(ROOT_DIR, "group_vars", "**", "*.yml"), recursive=True)
+    var_files += glob.glob(os.path.join(ROOT_DIR, "host_vars", "**", "*.yml"), recursive=True)
+    for path in var_files:
+        data = load_yaml(path)
+        if isinstance(data, dict):
+            defined.update(_gather_keys(data))
+
+    # Role defaults/vars
+    for role in find_roles(ROOT_DIR):
+        role_vars = glob.glob(os.path.join(role, "defaults", "*.yml"))
+        role_vars += glob.glob(os.path.join(role, "vars", "*.yml"))
+        for path in role_vars:
+            data = load_yaml(path)
+            if isinstance(data, dict):
+                defined.update(_gather_keys(data))
+
+    return defined
+
+
+def main() -> None:
+    """Run the audit and write ``validation_report.md``."""
+
+    defined_vars = load_all_defined_vars()
+    report: Dict[str, Dict[str, List[str]]] = {}
+    valid_roles: List[str] = []
+
+    for role in find_roles(ROOT_DIR):
+        role_name = os.path.basename(role)
+        findings = check_role(role, defined_vars)
+        if any(findings.values()):
+            report[role_name] = findings
+        else:
+            valid_roles.append(role_name)
+
+    lines: List[str] = []
+    lines.append("## ✅ Valid Items")
+    if valid_roles:
+        for r in sorted(valid_roles):
+            lines.append(f"- roles/{r}")
+    else:
+        lines.append("- None")
+
+    lines.append("\n## ❌ Missing or Broken")
+    if report:
+        for role, info in report.items():
+            for category in ("missing", "broken", "undefined_vars"):
+                for item in info.get(category, []):
+                    lines.append(f"- {role}: {item}")
+    else:
+        lines.append("- None")
+
+    lines.append("\n## ⚠️ Placeholders Detected")
+    placeholders = [
+        f"- {role}: {path}"
+        for role, info in report.items()
+        for path in info.get("placeholders", [])
+    ]
+    lines.extend(placeholders or ["- None"])
+
+    lines.append("\n## 🛠 Fix Recommendations")
+    if report:
+        for role, info in report.items():
+            if info.get("missing"):
+                lines.append(
+                    f"- Add {', '.join(info['missing'])} to roles/{role}"
+                )
+            if info.get("broken"):
+                lines.append(
+                    f"- Review tasks/handlers in roles/{role} for missing tags or handlers"
+                )
+            if info.get("undefined_vars"):
+                lines.append(
+                    f"- Define variables {', '.join(info['undefined_vars'])}"
+                )
+    else:
+        lines.append("- No issues found")
+
+    with open(os.path.join(ROOT_DIR, "validation_report.md"), "w") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+    print("Validation report written to validation_report.md")
+
+if __name__ == "__main__":
+    main()

--- a/validation_report.md
+++ b/validation_report.md
@@ -1,0 +1,450 @@
+## ✅ Valid Items
+- None
+
+## ❌ Missing or Broken
+- galera: defaults directory
+- galera: files directory
+- galera: handlers directory
+- galera: meta directory
+- galera: meta/main.yml
+- galera: vars directory
+- galera: /workspace/powerdns-ansible/roles/galera/tasks/main.yml missing tags for: Install Galera cluster packages, Stop MySQL service before cluster setup, Create Galera configuration, Create Galera cluster state directory, Configure MySQL for Galera, Create Galera cluster bootstrap script, Create Galera cluster management scripts, Bootstrap Galera cluster (first node only), Wait for bootstrap node to be ready, Start MySQL service on remaining nodes, Wait for Galera cluster to sync, Verify Galera cluster status, Display Galera cluster information, Create Galera monitoring user, Configure Galera cluster health checks, Configure Galera cluster health check timer, Create Galera backup script, Schedule Galera cluster backups, Configure firewall for Galera cluster, Create Galera cluster status dashboard, Enable Galera health monitoring, Test Galera cluster functionality, Display Galera test results, Create Galera cluster recovery procedures
+- galera: /workspace/powerdns-ansible/roles/galera/tasks/main.yml notifies undefined handler 'reload systemd'
+- galera: /workspace/powerdns-ansible/roles/galera/tasks/main.yml notifies undefined handler 'restart galera-health-check'
+- galera: /workspace/powerdns-ansible/roles/galera/tasks/main.yml notifies undefined handler 'restart mysql'
+- galera: /workspace/powerdns-ansible/roles/galera/tasks/main.yml notifies undefined handler 'start galera-health-check-timer'
+- galera: ansible_date_time.epoch
+- galera: ansible_default_ipv4.address
+- galera: galera_config_path[ansible_os_family]
+- galera: galera_packages[ansible_os_family]
+- galera: hostvars[groups['galera_cluster'][0]]['ansible_default_ipv4']['address']
+- galera: inventory_hostname
+- galera: item
+- galera: mysql_galera_config_path[ansible_os_family]
+- self_healing: defaults directory
+- self_healing: files directory
+- self_healing: meta directory
+- self_healing: meta/main.yml
+- self_healing: vars directory
+- self_healing: /workspace/powerdns-ansible/roles/self_healing/tasks/main.yml missing tags for: Create self-healing directories, Create configuration hash tracking, Create service health monitor, Create drift detection script, Create auto-recovery script, Create systemd watchdog service for PowerDNS, Create systemd watchdog timer, Create MySQL watchdog service, Create MySQL watchdog timer, Create configuration baseline, Schedule drift detection, Schedule service health monitoring, Create self-healing notification script, Configure logrotate for self-healing logs, Create Ansible pull configuration for GitOps, Schedule Ansible pull for GitOps, Create performance monitoring script, Schedule performance monitoring, Create backup verification script, Schedule backup verification, Enable and start watchdog services, Create self-healing dashboard script, Create self-healing status check, Test self-healing functionality, Display self-healing test result
+- self_healing: ansible_default_ipv4.address
+- self_healing: gitops_repo_url
+- self_healing: item
+- self_healing: powerdns_api_key
+- self_healing: powerdns_config_dir
+- self_healing: powerdns_db_password
+- haproxy: defaults directory
+- haproxy: files directory
+- haproxy: meta directory
+- haproxy: meta/main.yml
+- haproxy: vars directory
+- haproxy: /workspace/powerdns-ansible/roles/haproxy/tasks/main.yml missing tags for: Install HAProxy, Install HAProxy stats packages, Create HAProxy configuration backup, Generate HAProxy configuration, Create HAProxy systemd override directory, Configure HAProxy systemd service overrides, Create HAProxy stats user, Configure HAProxy log rotation, Create HAProxy management scripts, Enable and start HAProxy service, Wait for HAProxy to start, Check HAProxy service status, Display HAProxy service status, Test HAProxy configuration, Create HAProxy monitoring user for database, Verify HAProxy is load balancing DNS, Display DNS load balancing test result
+- haproxy: ansible_date_time.epoch
+- haproxy: ansible_date_time.iso8601
+- haproxy: ansible_default_ipv4.address
+- haproxy: haproxy_service_status.status.ActiveState
+- haproxy: hostvars[host]['ansible_default_ipv4']['address']
+- haproxy: hostvars[host]['inventory_hostname']
+- haproxy: item
+- zones_as_code: defaults directory
+- zones_as_code: files directory
+- zones_as_code: handlers directory
+- zones_as_code: meta directory
+- zones_as_code: meta/main.yml
+- zones_as_code: templates directory
+- zones_as_code: vars directory
+- zones_as_code: /workspace/powerdns-ansible/roles/zones_as_code/tasks/main.yml missing tags for: Create zones-as-code directories, Install zones-as-code dependencies, Install Python dependencies for zones management, Create zone management scripts, Create zone template files, Create zone schema validation, Generate zones from inventory, Create zone configuration from inventory, Create zone files from templates, Create reverse zone files, Validate zone configurations, Deploy zones to PowerDNS, Create zone backup before changes, Set up Git repository for zones, Configure Git hooks for zone validation, Create zone monitoring and alerting, Schedule zone monitoring, Create zone API integration, Create zone synchronization script, Schedule zone synchronization, Create zone rollback mechanism, Create zone management CLI, Create zone management web interface (optional), Configure zone change notifications, Create zone documentation generator, Generate zone documentation, Create zone testing framework, Run zone tests, Create zone performance monitoring, Schedule zone performance monitoring, Display zones-as-code setup summary
+- zones_as_code: item
+- zones_as_code: zones_git_repo
+- powerdns: defaults directory
+- powerdns: files directory
+- powerdns: handlers directory
+- powerdns: meta directory
+- powerdns: meta/main.yml
+- powerdns: vars directory
+- powerdns: /workspace/powerdns-ansible/roles/powerdns/tasks/configure_secondary.yml missing tags for: Add master server as supermaster, Create slave zones for primary domains, Create slave zones for reverse zones, Create slave zones for AD domains, Get slave domain count, Display slave zones created, Force zone transfers from master, Wait for zone transfers to complete, Verify zone transfers, Display zone transfer status
+- powerdns: /workspace/powerdns-ansible/roles/powerdns/tasks/create_zones.yml missing tags for: Create primary domains, Create reverse zones, Get domain IDs for primary domains, Create SOA records for primary domains, Create NS records for primary domains, Create A records for nameservers, Create basic A records for primary domains, Create MX records for primary domains, Create TXT records for primary domains, Create PTR records for reverse zones, Display created zones
+- powerdns: /workspace/powerdns-ansible/roles/powerdns/tasks/main.yml missing tags for: Install PowerDNS packages, Ensure PowerDNS MySQL backend .so exists, Fail if PowerDNS MySQL backend is missing, Ensure PowerDNS MySQL backend is installed, Ensure PowerDNS config directory exists, Stop PowerDNS service for initial configuration, Create PowerDNS configuration backup, Check if PowerDNS config exists, Generate PowerDNS configuration, Create PowerDNS systemd override directory, Configure PowerDNS systemd service overrides, Enable and start PowerDNS service, Wait for PowerDNS to start, Wait for PowerDNS API to start, Check PowerDNS service status, Display PowerDNS service status, Dry-run PowerDNS config check before enable/start, Display PowerDNS config validation result, Create initial zones for primary server, Configure secondary server zones, Install PowerDNS utilities, Create PowerDNS management scripts, Configure PowerDNS log rotation, Create PowerDNS monitoring user (if API enabled), Verify PowerDNS is responding to queries, Display DNS test result, Install DNSSEC utilities, Enable DNSSEC for primary domains, Generate DNSSEC keys for domains, Generate DNSSEC ZSK keys for domains, Activate DNSSEC keys, Set up automatic DNSSEC key rollover, Verify DNSSEC status, Display DNSSEC status, Create zone validation script, Validate zones after creation, Display zone validation results, Create PowerDNS API management script, Test PowerDNS API connectivity, Display API test result
+- powerdns: /workspace/powerdns-ansible/roles/powerdns/tasks/main.yml notifies undefined handler 'reload systemd'
+- powerdns: /workspace/powerdns-ansible/roles/powerdns/tasks/main.yml notifies undefined handler 'restart powerdns'
+- powerdns: ad_domains
+- powerdns: ansible_date_time.epoch
+- powerdns: ansible_date_time.iso8601
+- powerdns: ansible_default_ipv4.address
+- powerdns: dnssec_status.results
+- powerdns: domain
+- powerdns: domain_ids.query_result
+- powerdns: item
+- powerdns: item.id
+- powerdns: item.item
+- powerdns: item.name
+- powerdns: logging_config.facility
+- powerdns: logging_config.level
+- powerdns: performance_config.cache_ttl
+- powerdns: performance_config.distributor_threads
+- powerdns: performance_config.max_queue_length
+- powerdns: performance_config.max_tcp_connections
+- powerdns: performance_config.negquery_cache_ttl
+- powerdns: performance_config.query_cache_ttl
+- powerdns: performance_config.receiver_threads
+- powerdns: performance_config.recursive_cache_ttl
+- powerdns: powerdns_api_key
+- powerdns: powerdns_backend
+- powerdns: powerdns_config_dir
+- powerdns: powerdns_db_password
+- powerdns: powerdns_group
+- powerdns: powerdns_packages[ansible_os_family]
+- powerdns: powerdns_service_status.status.ActiveState
+- powerdns: powerdns_user
+- powerdns: record.name
+- powerdns: record.type
+- powerdns: record.value
+- powerdns: reverse_zones
+- powerdns: slave_domain_count.query_result[0].count
+- powerdns: zone_transfer_status.query_result
+- powerdns: zone_validation.results
+- state_management: defaults directory
+- state_management: files directory
+- state_management: handlers directory
+- state_management: meta directory
+- state_management: meta/main.yml
+- state_management: vars directory
+- state_management: /workspace/powerdns-ansible/roles/state_management/tasks/main.yml missing tags for: Create state management directories, Install state management dependencies, Create configuration hash tracking script, Create state report generator, Create drift detection script, Generate initial configuration hashes, Create current system state snapshot, Store deployment metadata, Create change tracking database, Record current deployment as change, Create service state tracking, Generate comprehensive state report, Create state monitoring cron job, Create state report cleanup job, Create state backup job, Create state validation script, Validate current state, Create rollback preparation script, Prepare rollback point, Create state notification script, Send state change notification, Create state query interface, Display state management summary, Create state management logrotate configuration
+- state_management: ansible_date_time.epoch
+- state_management: ansible_date_time.iso8601
+- state_management: ansible_default_ipv4.address
+- state_management: ansible_distribution
+- state_management: ansible_distribution_version
+- state_management: ansible_kernel
+- state_management: ansible_user_id
+- state_management: ansible_version.full
+- state_management: inventory_hostname
+- state_management: item
+- security_hardening: defaults directory
+- security_hardening: files directory
+- security_hardening: meta directory
+- security_hardening: meta/main.yml
+- security_hardening: vars directory
+- security_hardening: /workspace/powerdns-ansible/roles/security_hardening/tasks/main.yml missing tags for: Display security hardening start, Install Fail2Ban, Create PowerDNS Fail2Ban filter, Create PowerDNS API Fail2Ban filter, Configure Fail2Ban jail for PowerDNS, Create DNS abuse filter, Enable and start Fail2Ban, Install AppArmor utilities (Debian/Ubuntu), Install SELinux utilities (RHEL/CentOS), Create PowerDNS AppArmor profile, Enable PowerDNS AppArmor profile, Create MySQL AppArmor profile enhancement, Configure SELinux for PowerDNS (RHEL/CentOS), Configure UFW firewall (Debian/Ubuntu), Configure FirewallD (RHEL/CentOS), Install SSL/TLS certificates, Disable unnecessary services, Configure kernel security parameters, Configure file permissions for sensitive files, Create security monitoring script, Schedule security monitoring, Create security status report, Display security hardening summary
+- security_hardening: /workspace/powerdns-ansible/roles/security_hardening/tasks/main.yml notifies undefined handler 'restart fail2ban'
+- security_hardening: ansible_date_time.iso8601
+- security_hardening: ansible_fqdn
+- security_hardening: hostvars[item]['ansible_default_ipv4']['address']
+- security_hardening: inventory_hostname
+- security_hardening: item
+- security_hardening: item.comment
+- security_hardening: item.direction
+- security_hardening: item.mode
+- security_hardening: item.name
+- security_hardening: item.owner
+- security_hardening: item.path
+- security_hardening: item.policy
+- security_hardening: item.port
+- security_hardening: item.proto
+- security_hardening: item.src
+- security_hardening: item.value
+- security_hardening: ssl_cert_path
+- security_hardening: ssl_key_path
+- keepalived: defaults directory
+- keepalived: files directory
+- keepalived: meta directory
+- keepalived: meta/main.yml
+- keepalived: vars directory
+- keepalived: /workspace/powerdns-ansible/roles/keepalived/tasks/main.yml missing tags for: Install keepalived, Install additional networking tools, Create keepalived configuration backup, Generate keepalived configuration, Create keepalived scripts directory, Create keepalived health check scripts, Configure sysctl for keepalived, Enable and start keepalived service, Check keepalived service status, Display keepalived service status, Test keepalived configuration, Create keepalived management scripts, Configure keepalived log rotation, Create keepalived monitoring cron job, Configure firewall for VRRP, Verify keepalived VRRP state, Display VRRP state, Create keepalived status check, Create keepalived status check timer, Enable keepalived status check timer
+- keepalived: alert_email
+- keepalived: ansible_date_time.epoch
+- keepalived: ansible_date_time.iso8601
+- keepalived: ansible_default_ipv4.address
+- keepalived: instance.name
+- keepalived: instance.router_id
+- keepalived: instance.vip
+- keepalived: inventory_hostname
+- keepalived: item
+- keepalived: item.comment
+- keepalived: item.name
+- keepalived: item.proto
+- keepalived: item.value
+- keepalived: keepalived_service_status.status.ActiveState
+- keepalived: keepalived_webhook_url
+- keepalived: powerdns_db_password
+- keepalived: script
+- keepalived: vrrp_state.stdout
+- validate_config: defaults directory
+- validate_config: files directory
+- validate_config: handlers directory
+- validate_config: meta directory
+- validate_config: meta/main.yml
+- validate_config: templates directory
+- validate_config: vars directory
+- validate_config: /workspace/powerdns-ansible/roles/validate_config/tasks/main.yml missing tags for: Display validation start message, Validate operation mode, Validate DNS features configuration, Validate server role, Check PowerDNS version format, Validate MySQL configuration, Check MySQL connectivity (if MySQL feature enabled), Validate DNSSEC configuration, Validate API configuration, Check zones configuration, Validate zone template syntax, Clean up validation files, Check system requirements, Validate network configuration, Check disk space, Validate firewall configuration, Check for conflicting services, Ensure no conflicting DNS services, Validate backup configuration, Check monitoring prerequisites, Validate SSL/TLS configuration, Check for existing PowerDNS installation, Compute existing configuration hash, Store configuration state, Validate upgrade path, Check package availability, Validate PowerDNS package availability, Create validation report, Display validation summary
+- validate_config: ansible_date_time.iso8601
+- validate_config: ansible_default_ipv4.address
+- validate_config: ansible_distribution
+- validate_config: ansible_distribution_version
+- validate_config: ansible_memtotal_mb
+- validate_config: ansible_mounts
+- validate_config: ansible_processor_vcpus
+- validate_config: backup_config.retention_days
+- validate_config: dnssec_key_algorithm
+- validate_config: existing_pdns_config.stat.exists
+- validate_config: inventory_hostname
+- validate_config: item
+- validate_config: item.mount
+- validate_config: pdns_config_hash
+- clean_install: defaults directory
+- clean_install: files directory
+- clean_install: meta directory
+- clean_install: meta/main.yml
+- clean_install: templates directory
+- clean_install: vars directory
+- clean_install: /workspace/powerdns-ansible/roles/clean_install/tasks/main.yml missing tags for: Display clean install warning, Pause for confirmation (only in interactive mode), Stop PowerDNS service, Stop MySQL/MariaDB service, Stop monitoring services, Remove PowerDNS packages (Debian/Ubuntu), Remove PowerDNS packages (RedHat/CentOS), Remove MySQL/MariaDB packages (Debian/Ubuntu), Remove MySQL/MariaDB packages (RedHat/CentOS), Remove additional PowerDNS tools, Remove PowerDNS data directories, Remove MySQL/MariaDB data directories, Remove MySQL/MariaDB configuration files, Remove PowerDNS systemd overrides, Remove PowerDNS management scripts, Remove monitoring scripts and services, Remove logrotate configurations, Remove security configurations, Remove system users created by playbook, Remove system groups created by playbook, Clean package cache (Debian/Ubuntu), Clean package cache (RedHat/CentOS), Reload systemd daemon after cleanup, Remove any remaining PowerDNS processes, Verify clean install completion, Skip clean install notification
+- clean_install: item
+- clean_install: mysql_packages[ansible_os_family]
+- clean_install: powerdns_packages[ansible_os_family]
+- monitoring: defaults directory
+- monitoring: files directory
+- monitoring: meta directory
+- monitoring: meta/main.yml
+- monitoring: vars directory
+- monitoring: /workspace/powerdns-ansible/roles/monitoring/tasks/install_prometheus.yml missing tags for: Check if Prometheus Node Exporter is already installed, Create prometheus user, Create prometheus directories, Download Prometheus Node Exporter, Extract Node Exporter, Copy Node Exporter binary, Create Node Exporter systemd service, Create PowerDNS custom metrics script, Create PowerDNS metrics collection service, Create PowerDNS metrics collection timer, Enable and start Node Exporter, Enable and start PowerDNS metrics collection, Configure firewall for Prometheus (if UFW is active), Configure firewall for Prometheus (if firewalld is active), Clean up downloaded files, Verify Node Exporter is running, Display Prometheus setup status
+- monitoring: /workspace/powerdns-ansible/roles/monitoring/tasks/main.yml missing tags for: Install monitoring packages, Create monitoring directories, Install PowerDNS monitoring script, Install system resource monitoring script, Install DNS query monitoring script, Create monitoring configuration, Schedule PowerDNS monitoring, Schedule system monitoring, Schedule DNS query monitoring, Configure log rotation for monitoring logs, Install alerting script, Create monitoring dashboard script, Install Prometheus node exporter (if enabled), Display monitoring setup status
+- monitoring: alert_email
+- monitoring: alert_webhook_url
+- monitoring: ansible_date_time.iso8601
+- monitoring: ansible_default_ipv4.address
+- monitoring: domain
+- monitoring: hostvars[host]['ansible_default_ipv4']['address']
+- monitoring: item
+- monitoring: loop.index
+- monitoring: monitoring_config.prometheus_port
+- monitoring: powerdns_api_key
+- monitoring: powerdns_db_password
+- monitoring: powerdns_webserver_port
+- monitoring: zone
+- prometheus: defaults directory
+- prometheus: files directory
+- prometheus: meta directory
+- prometheus: meta/main.yml
+- prometheus: vars directory
+- prometheus: /workspace/powerdns-ansible/roles/prometheus/tasks/main.yml missing tags for: Create prometheus system user, Create prometheus directories, Download and install Prometheus, Copy Prometheus binaries, Create Prometheus configuration, Create Prometheus systemd service, Download and install PowerDNS Exporter, Extract PowerDNS Exporter, Install PowerDNS Exporter binary, Create PowerDNS Exporter systemd service, Download and install Node Exporter, Install Node Exporter binary, Create Node Exporter systemd service, Install MySQL Exporter (if MySQL monitoring enabled), Create Grafana dashboards directory, Install PowerDNS Grafana dashboard, Configure firewall for Prometheus, Enable and start monitoring services, Create monitoring health check script, Schedule monitoring health checks, Verify Prometheus is accessible, Display Prometheus status
+- prometheus: ansible_date_time.iso8601
+- prometheus: ansible_default_ipv4.address
+- prometheus: hostvars[host]['ansible_default_ipv4']['address']
+- prometheus: item
+- prometheus: powerdns_api_key
+- prometheus: prometheus_remote_write_password
+- prometheus: prometheus_remote_write_url
+- prometheus: prometheus_remote_write_username
+- selfheal: defaults directory
+- selfheal: files directory
+- selfheal: meta directory
+- selfheal: meta/main.yml
+- selfheal: vars directory
+- selfheal: /workspace/powerdns-ansible/roles/selfheal/tasks/main.yml missing tags for: Display self-healing start message, Ensure PowerDNS MySQL backend is installed, Ensure PowerDNS service file exists, Reinstall PowerDNS if service file is missing, Ensure MySQL service file exists, Reinstall MySQL if service file is missing, Create systemd service overrides for resilience, Add PowerDNS systemd watchdog override, Add MySQL systemd watchdog override, Check for port conflicts, Display port usage, Stop conflicting services on DNS port, Create self-healing health check script, Create self-healing systemd service, Create self-healing timer, Enable self-healing timer, Create failure log collection script, Collect logs if services failed during this run, Final service status check, Display final service status, Create self-healing status report, Display self-healing completion summary
+- selfheal: ansible_date_time.iso8601
+- selfheal: ansible_default_ipv4.address
+- selfheal: config_check_result.stdout
+- selfheal: final_service_check.results
+- selfheal: inventory_hostname
+- selfheal: item
+- selfheal: item.group
+- selfheal: item.home
+- selfheal: item.item
+- selfheal: item.line
+- selfheal: item.mode
+- selfheal: item.name
+- selfheal: item.owner
+- selfheal: item.path
+- selfheal: item.regexp
+- selfheal: item.status.ActiveState
+- selfheal: mysql_error_log.stdout_lines
+- selfheal: mysql_packages[ansible_os_family]
+- selfheal: port_conflicts.stdout_lines
+- selfheal: powerdns_api_key
+- selfheal: powerdns_db_password
+- selfheal: powerdns_mysql_backend_packages[ansible_os_family]
+- security: defaults directory
+- security: files directory
+- security: meta directory
+- security: meta/main.yml
+- security: vars directory
+- security: /workspace/powerdns-ansible/roles/security/tasks/configure_aide.yml missing tags for: Install AIDE, Check if AIDE database exists, Create AIDE configuration, Initialize AIDE database (first time), Move new AIDE database to active location, Create AIDE check script, Create AIDE update script, Schedule daily AIDE checks, Schedule weekly AIDE database updates, Create AIDE log directory, Configure AIDE log rotation, Set proper permissions on AIDE files, Display AIDE setup status
+- security: /workspace/powerdns-ansible/roles/security/tasks/configure_firewalld.yml missing tags for: Start and enable firewalld, Set default zone to public, Configure DNS firewall rules, Allow SSH access, Allow PowerDNS API access, Allow database access from localhost, Allow monitoring ports (if Prometheus is enabled), Allow NTP, Create rich rules for zone transfers between DNS servers, Set firewalld default target to DROP, Enable firewalld logging, Reload firewalld configuration, Check firewalld status, Display firewalld status
+- security: /workspace/powerdns-ansible/roles/security/tasks/configure_ufw.yml missing tags for: Reset UFW to defaults, Set UFW default policies, Allow SSH access, Configure DNS firewall rules, Allow PowerDNS API access from management networks, Allow zone transfers between DNS servers, Allow database access from localhost, Allow monitoring ports (if Prometheus is enabled), Allow NTP, Deny all other incoming traffic, Enable UFW logging, Enable UFW, Check UFW status, Display UFW status
+- security: /workspace/powerdns-ansible/roles/security/tasks/main.yml missing tags for: Install security packages, Install security packages (RHEL), Configure UFW firewall (Debian/Ubuntu), Configure firewalld (RHEL/CentOS), Configure fail2ban, Enable and start fail2ban, Configure SSH security, Set secure file permissions, Configure system audit rules, Install and configure AIDE (file integrity monitoring), Configure kernel security parameters, Create security monitoring script, Schedule security monitoring, Configure log monitoring, Disable unnecessary services, Remove unnecessary packages, Configure password policies, Create security report, Display security status
+- security: alert_email
+- security: alert_webhook_url
+- security: ansible_date_time.iso8601
+- security: ansible_default_ipv4.address
+- security: ansible_fqdn
+- security: groups['powerdns_servers']
+- security: hostvars[item]["ansible_default_ipv4"]["address"]
+- security: hostvars[item]['ansible_default_ipv4']['address']
+- security: item
+- security: item.comment
+- security: item.direction
+- security: item.line
+- security: item.mode
+- security: item.name
+- security: item.path
+- security: item.policy
+- security: item.port
+- security: item.proto
+- security: item.regexp
+- security: item.value
+- security: monitoring_config.prometheus_port
+- security: powerdns_config_dir
+- security: powerdns_db_password
+- security: powerdns_group
+- security: powerdns_webserver_port
+- dnsdist: defaults directory
+- dnsdist: files directory
+- dnsdist: handlers directory
+- dnsdist: meta directory
+- dnsdist: meta/main.yml
+- dnsdist: vars directory
+- dnsdist: /workspace/powerdns-ansible/roles/dnsdist/tasks/main.yml missing tags for: Create dnsdist system user, Install DNSdist packages, Create DNSdist directories, Generate DNSdist configuration, Create DNSdist systemd override, Configure DNSdist health checks, Create DNSdist management scripts, Configure firewall for DNSdist, Enable and start DNSdist service, Wait for DNSdist to start, Test DNSdist functionality, Display DNSdist test result, Create DNSdist monitoring configuration, Schedule DNSdist statistics collection
+- dnsdist: /workspace/powerdns-ansible/roles/dnsdist/tasks/main.yml notifies undefined handler 'reload systemd'
+- dnsdist: /workspace/powerdns-ansible/roles/dnsdist/tasks/main.yml notifies undefined handler 'restart dnsdist'
+- dnsdist: ansible_date_time.iso8601
+- dnsdist: ansible_default_ipv4.address
+- dnsdist: dnsdist_packages[ansible_os_family]
+- dnsdist: domain
+- dnsdist: geo_rule.country
+- dnsdist: geo_rule.pool
+- dnsdist: hostvars[host]['ansible_default_ipv4']['address']
+- dnsdist: item
+- dnsdist: loop.index
+- dnsdist: rule.lua_code
+- dnsdist: zone
+- dnssec_automation: defaults directory
+- dnssec_automation: files directory
+- dnssec_automation: handlers directory
+- dnssec_automation: meta directory
+- dnssec_automation: meta/main.yml
+- dnssec_automation: templates directory
+- dnssec_automation: vars directory
+- dnssec_automation: /workspace/powerdns-ansible/roles/dnssec_automation/tasks/main.yml missing tags for: Display DNSSEC automation start, Install DNSSEC dependencies, Create DNSSEC management directories, Create DNSSEC key management script, Create DNSSEC zone signing script, Create DNSSEC validation script, Get list of zones to secure, Secure zones with DNSSEC, Generate DNSSEC keys for zones, Activate DNSSEC keys, Validate DNSSEC zone signing, Export DS records for parent zone delegation, Save DS records to file, Create DNSSEC key rollover script, Schedule DNSSEC key rollover, Create DNSSEC monitoring script, Schedule DNSSEC monitoring, Create DNSSEC backup script, Schedule DNSSEC key backups, Test DNSSEC resolution, Create DNSSEC status report, Display DNSSEC automation summary
+- dnssec_automation: ansible_date_time.iso8601
+- dnssec_automation: ansible_default_ipv4.address
+- dnssec_automation: inventory_hostname
+- dnssec_automation: item
+- dnssec_automation: item.item.name
+- dnssec_automation: item.name
+- dnssec_automation: item.stdout
+- dnssec_automation: powerdns_db_password
+- common: defaults directory
+- common: files directory
+- common: meta directory
+- common: meta/main.yml
+- common: vars directory
+- common: /workspace/powerdns-ansible/roles/common/tasks/main.yml missing tags for: Update package cache, Install common packages, Ensure system group for pdns (Debian), Ensure system group for pdns (RHEL), Ensure pdns system user exists, Create PowerDNS directories, Set up log rotation for PowerDNS, Configure system limits for PowerDNS, Configure sysctl parameters for DNS performance, Ensure system-wide DB clients are present, Create backup script, Schedule backup cron job, Install health check script, Create systemd timer for health checks, Create systemd service for health checks, Force systemd to reload after creating health check files, Ensure systemd daemon is reloaded before starting timer, Verify health check timer file exists, Verify health check service file exists, Check if systemd files would be created (check mode), Enable and start health check timer, Show what would happen with health check timer (check mode)
+- common: alert_email
+- common: item
+- common: item.name
+- common: item.value
+- common: powerdns_config_dir
+- common: powerdns_db_password
+- common: powerdns_group
+- common: powerdns_user
+- mysql: defaults directory
+- mysql: files directory
+- mysql: meta directory
+- mysql: meta/main.yml
+- mysql: vars directory
+- mysql: /workspace/powerdns-ansible/roles/mysql/tasks/main.yml missing tags for: Ensure MySQL config directories exist, Install MySQL/MariaDB packages, Ensure Python MySQL packages are installed for Ansible modules, Ensure Python MySQL packages are installed for Ansible modules (RHEL), Verify Python MySQL module availability, Display Python MySQL module status, Start and enable MySQL/MariaDB service, Wait for MySQL to be ready, Secure MySQL installation, Create MySQL configuration file for root, Remove anonymous MySQL users, Remove MySQL test database, Create PowerDNS database, Create PowerDNS database user with minimal privileges, Configure MySQL for PowerDNS performance, Configure MariaDB for PowerDNS performance (RHEL), Create PowerDNS database schema, Create custom PowerDNS schema if standard not found, Verify database schema, Display database tables, Create database backup user, Configure MySQL slow query log, Configure MySQL slow query log file, Set MySQL slow query time threshold, Configure MySQL for replication (Master), Configure MySQL for replication (Slave), Create replication user on master, Get master status, Configure slave replication, Start slave replication, Check slave status, Display replication status, Create MySQL failover scripts, Create MySQL monitoring user for HAProxy, Configure MySQL for high availability, Wait for MySQL to be ready with retries, Validate MySQL is reachable from PowerDNS node, Display MySQL connectivity test result, Ensure PowerDNS DB schema is present, Display schema validation result
+- mysql: ansible_date_time.iso8601
+- mysql: ansible_default_ipv4.address
+- mysql: ansible_python_interpreter
+- mysql: db_tables.rowcount[0]
+- mysql: hostvars[mysql_master_host]['mysql_master_status']['query_result'][0]['File']
+- mysql: hostvars[mysql_master_host]['mysql_master_status']['query_result'][0]['Position']
+- mysql: item
+- mysql: item.name
+- mysql: item.value
+- mysql: mysql_packages[ansible_os_family]
+- mysql: mysql_replication_config_path[ansible_os_family]
+- mysql: mysql_root_password
+- mysql: powerdns_db_password
+- recursor: defaults directory
+- recursor: files directory
+- recursor: meta directory
+- recursor: meta/main.yml
+- recursor: vars directory
+- recursor: /workspace/powerdns-ansible/roles/recursor/tasks/main.yml missing tags for: Install PowerDNS Recursor packages, Create PowerDNS Recursor configuration directory, Create PowerDNS Recursor log directory, Stop PowerDNS Recursor service for initial configuration, Create PowerDNS Recursor configuration backup, Generate PowerDNS Recursor configuration, Create PowerDNS Recursor systemd override directory, Configure PowerDNS Recursor systemd service overrides, Create PowerDNS Recursor forward zones configuration, Create PowerDNS Recursor Lua configuration, Enable and start PowerDNS Recursor service, Wait for PowerDNS Recursor to start, Wait for PowerDNS Recursor API to start, Check PowerDNS Recursor service status, Display PowerDNS Recursor service status, Test PowerDNS Recursor configuration, Create PowerDNS Recursor management scripts, Configure PowerDNS Recursor log rotation, Create PowerDNS Recursor monitoring cron job, Verify PowerDNS Recursor is responding to queries, Display PowerDNS Recursor test result, Configure firewall for PowerDNS Recursor, Configure firewall for PowerDNS Recursor API
+- recursor: ansible_date_time.epoch
+- recursor: ansible_date_time.iso8601
+- recursor: ansible_default_ipv4.address
+- recursor: domain
+- recursor: item
+- recursor: item.comment
+- recursor: item.port
+- recursor: item.proto
+- recursor: key
+- recursor: record
+- recursor: recursor_packages[ansible_os_family]
+- recursor: recursor_service_status.status.ActiveState
+- recursor: value
+- recursor: zone
+
+## ⚠️ Placeholders Detected
+- None
+
+## 🛠 Fix Recommendations
+- Add defaults directory, files directory, handlers directory, meta directory, meta/main.yml, vars directory to roles/galera
+- Review tasks/handlers in roles/galera for missing tags or handlers
+- Define variables ansible_date_time.epoch, ansible_default_ipv4.address, galera_config_path[ansible_os_family], galera_packages[ansible_os_family], hostvars[groups['galera_cluster'][0]]['ansible_default_ipv4']['address'], inventory_hostname, item, mysql_galera_config_path[ansible_os_family]
+- Add defaults directory, files directory, meta directory, meta/main.yml, vars directory to roles/self_healing
+- Review tasks/handlers in roles/self_healing for missing tags or handlers
+- Define variables ansible_default_ipv4.address, gitops_repo_url, item, powerdns_api_key, powerdns_config_dir, powerdns_db_password
+- Add defaults directory, files directory, meta directory, meta/main.yml, vars directory to roles/haproxy
+- Review tasks/handlers in roles/haproxy for missing tags or handlers
+- Define variables ansible_date_time.epoch, ansible_date_time.iso8601, ansible_default_ipv4.address, haproxy_service_status.status.ActiveState, hostvars[host]['ansible_default_ipv4']['address'], hostvars[host]['inventory_hostname'], item
+- Add defaults directory, files directory, handlers directory, meta directory, meta/main.yml, templates directory, vars directory to roles/zones_as_code
+- Review tasks/handlers in roles/zones_as_code for missing tags or handlers
+- Define variables item, zones_git_repo
+- Add defaults directory, files directory, handlers directory, meta directory, meta/main.yml, vars directory to roles/powerdns
+- Review tasks/handlers in roles/powerdns for missing tags or handlers
+- Define variables ad_domains, ansible_date_time.epoch, ansible_date_time.iso8601, ansible_default_ipv4.address, dnssec_status.results, domain, domain_ids.query_result, item, item.id, item.item, item.name, logging_config.facility, logging_config.level, performance_config.cache_ttl, performance_config.distributor_threads, performance_config.max_queue_length, performance_config.max_tcp_connections, performance_config.negquery_cache_ttl, performance_config.query_cache_ttl, performance_config.receiver_threads, performance_config.recursive_cache_ttl, powerdns_api_key, powerdns_backend, powerdns_config_dir, powerdns_db_password, powerdns_group, powerdns_packages[ansible_os_family], powerdns_service_status.status.ActiveState, powerdns_user, record.name, record.type, record.value, reverse_zones, slave_domain_count.query_result[0].count, zone_transfer_status.query_result, zone_validation.results
+- Add defaults directory, files directory, handlers directory, meta directory, meta/main.yml, vars directory to roles/state_management
+- Review tasks/handlers in roles/state_management for missing tags or handlers
+- Define variables ansible_date_time.epoch, ansible_date_time.iso8601, ansible_default_ipv4.address, ansible_distribution, ansible_distribution_version, ansible_kernel, ansible_user_id, ansible_version.full, inventory_hostname, item
+- Add defaults directory, files directory, meta directory, meta/main.yml, vars directory to roles/security_hardening
+- Review tasks/handlers in roles/security_hardening for missing tags or handlers
+- Define variables ansible_date_time.iso8601, ansible_fqdn, hostvars[item]['ansible_default_ipv4']['address'], inventory_hostname, item, item.comment, item.direction, item.mode, item.name, item.owner, item.path, item.policy, item.port, item.proto, item.src, item.value, ssl_cert_path, ssl_key_path
+- Add defaults directory, files directory, meta directory, meta/main.yml, vars directory to roles/keepalived
+- Review tasks/handlers in roles/keepalived for missing tags or handlers
+- Define variables alert_email, ansible_date_time.epoch, ansible_date_time.iso8601, ansible_default_ipv4.address, instance.name, instance.router_id, instance.vip, inventory_hostname, item, item.comment, item.name, item.proto, item.value, keepalived_service_status.status.ActiveState, keepalived_webhook_url, powerdns_db_password, script, vrrp_state.stdout
+- Add defaults directory, files directory, handlers directory, meta directory, meta/main.yml, templates directory, vars directory to roles/validate_config
+- Review tasks/handlers in roles/validate_config for missing tags or handlers
+- Define variables ansible_date_time.iso8601, ansible_default_ipv4.address, ansible_distribution, ansible_distribution_version, ansible_memtotal_mb, ansible_mounts, ansible_processor_vcpus, backup_config.retention_days, dnssec_key_algorithm, existing_pdns_config.stat.exists, inventory_hostname, item, item.mount, pdns_config_hash
+- Add defaults directory, files directory, meta directory, meta/main.yml, templates directory, vars directory to roles/clean_install
+- Review tasks/handlers in roles/clean_install for missing tags or handlers
+- Define variables item, mysql_packages[ansible_os_family], powerdns_packages[ansible_os_family]
+- Add defaults directory, files directory, meta directory, meta/main.yml, vars directory to roles/monitoring
+- Review tasks/handlers in roles/monitoring for missing tags or handlers
+- Define variables alert_email, alert_webhook_url, ansible_date_time.iso8601, ansible_default_ipv4.address, domain, hostvars[host]['ansible_default_ipv4']['address'], item, loop.index, monitoring_config.prometheus_port, powerdns_api_key, powerdns_db_password, powerdns_webserver_port, zone
+- Add defaults directory, files directory, meta directory, meta/main.yml, vars directory to roles/prometheus
+- Review tasks/handlers in roles/prometheus for missing tags or handlers
+- Define variables ansible_date_time.iso8601, ansible_default_ipv4.address, hostvars[host]['ansible_default_ipv4']['address'], item, powerdns_api_key, prometheus_remote_write_password, prometheus_remote_write_url, prometheus_remote_write_username
+- Add defaults directory, files directory, meta directory, meta/main.yml, vars directory to roles/selfheal
+- Review tasks/handlers in roles/selfheal for missing tags or handlers
+- Define variables ansible_date_time.iso8601, ansible_default_ipv4.address, config_check_result.stdout, final_service_check.results, inventory_hostname, item, item.group, item.home, item.item, item.line, item.mode, item.name, item.owner, item.path, item.regexp, item.status.ActiveState, mysql_error_log.stdout_lines, mysql_packages[ansible_os_family], port_conflicts.stdout_lines, powerdns_api_key, powerdns_db_password, powerdns_mysql_backend_packages[ansible_os_family]
+- Add defaults directory, files directory, meta directory, meta/main.yml, vars directory to roles/security
+- Review tasks/handlers in roles/security for missing tags or handlers
+- Define variables alert_email, alert_webhook_url, ansible_date_time.iso8601, ansible_default_ipv4.address, ansible_fqdn, groups['powerdns_servers'], hostvars[item]["ansible_default_ipv4"]["address"], hostvars[item]['ansible_default_ipv4']['address'], item, item.comment, item.direction, item.line, item.mode, item.name, item.path, item.policy, item.port, item.proto, item.regexp, item.value, monitoring_config.prometheus_port, powerdns_config_dir, powerdns_db_password, powerdns_group, powerdns_webserver_port
+- Add defaults directory, files directory, handlers directory, meta directory, meta/main.yml, vars directory to roles/dnsdist
+- Review tasks/handlers in roles/dnsdist for missing tags or handlers
+- Define variables ansible_date_time.iso8601, ansible_default_ipv4.address, dnsdist_packages[ansible_os_family], domain, geo_rule.country, geo_rule.pool, hostvars[host]['ansible_default_ipv4']['address'], item, loop.index, rule.lua_code, zone
+- Add defaults directory, files directory, handlers directory, meta directory, meta/main.yml, templates directory, vars directory to roles/dnssec_automation
+- Review tasks/handlers in roles/dnssec_automation for missing tags or handlers
+- Define variables ansible_date_time.iso8601, ansible_default_ipv4.address, inventory_hostname, item, item.item.name, item.name, item.stdout, powerdns_db_password
+- Add defaults directory, files directory, meta directory, meta/main.yml, vars directory to roles/common
+- Review tasks/handlers in roles/common for missing tags or handlers
+- Define variables alert_email, item, item.name, item.value, powerdns_config_dir, powerdns_db_password, powerdns_group, powerdns_user
+- Add defaults directory, files directory, meta directory, meta/main.yml, vars directory to roles/mysql
+- Review tasks/handlers in roles/mysql for missing tags or handlers
+- Define variables ansible_date_time.iso8601, ansible_default_ipv4.address, ansible_python_interpreter, db_tables.rowcount[0], hostvars[mysql_master_host]['mysql_master_status']['query_result'][0]['File'], hostvars[mysql_master_host]['mysql_master_status']['query_result'][0]['Position'], item, item.name, item.value, mysql_packages[ansible_os_family], mysql_replication_config_path[ansible_os_family], mysql_root_password, powerdns_db_password
+- Add defaults directory, files directory, meta directory, meta/main.yml, vars directory to roles/recursor
+- Review tasks/handlers in roles/recursor for missing tags or handlers
+- Define variables ansible_date_time.epoch, ansible_date_time.iso8601, ansible_default_ipv4.address, domain, item, item.comment, item.port, item.proto, key, record, recursor_packages[ansible_os_family], recursor_service_status.status.ActiveState, value, zone


### PR DESCRIPTION
## Summary
- refine `audit_ansible.py` to aggregate missing tags and detect meta files
- include group/host vars when collecting defined variables
- drop generated `audit_output.yaml` from version control
- ignore `audit_output.yaml` via `.gitignore`
- regenerate `validation_report.md`

## Testing
- `python3 -m py_compile audit_ansible.py`
- `python3 audit_ansible.py > /tmp/out.txt`


------
https://chatgpt.com/codex/tasks/task_e_687e1b1844848333a7cf1349d79e908d