### PR TITLE
Add rate limiter and logging to AuditAgent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for AuditAgent
+AGENT_API_KEY=changeme
+LOG_LEVEL=INFO
+LOG_DIR=logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "src/cli.py", "run"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+install:
+pip install -r requirements.txt
+
+test:
+pytest -q --cov=src --cov-report=term-missing
+
+run:
+python src/cli.py run
+
+lint:
+black src tests

--- a/README_AGENT.md
+++ b/README_AGENT.md
@@ -1,0 +1,28 @@
+# AuditAgent
+
+AuditAgent scans an Ansible collection or playbook directory and generates a `validation_report.md` highlighting missing files, undefined variables, and placeholder content.
+
+## Features
+
+- CLI and REST API interfaces
+- JSON structured logging
+- API key authentication
+- Rate limiting
+- Audit logs written to `logs/`
+- Asynchronous API endpoints with rate limiting
+- Docker and docker-compose support
+
+## Usage
+
+```bash
+# Install dependencies
+make install
+
+# Run audit
+make run
+
+# Run tests
+make test
+```
+
+Environment variables can be placed in `.env` or exported before running. See `.env.example` for details.

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,0 +1,18 @@
+audit:
+  required_role_dirs:
+    - tasks
+    - defaults
+    - handlers
+    - meta
+    - vars
+    - templates
+    - files
+  placeholder_keywords:
+    - TODO
+    - REPLACE_ME
+    - FIXME
+rate_limit:
+  max_calls: 5
+  period: 60
+api:
+  api_key_env: AGENT_API_KEY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.9'
+services:
+  audit-agent:
+    build: .
+    environment:
+      - AGENT_API_KEY=${AGENT_API_KEY}
+    volumes:
+      - .:/app
+    command: uvicorn api.server:app --host 0.0.0.0 --port 8000

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths =
+    tests/test_agent.py
+    tests/test_api.py
+addopts = -ra

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pyyaml
+rich
+httpx

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,0 +1,5 @@
+"""Audit agent package."""
+
+from .audit_agent import AuditAgent
+
+__all__ = ["AuditAgent"]

--- a/src/agent/audit_agent.py
+++ b/src/agent/audit_agent.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import os
+import re
+from typing import Dict, List
+
+import yaml
+
+from utils.logger import get_logger
+
+
+class AuditAgent:
+    """Audit Ansible roles and generate a validation report."""
+
+    VARIABLE_PATTERN = re.compile(r"{{\s*([^\s{}|]+)\s*}}")
+
+    def __init__(self, root_dir: str, config: Dict[str, any]):
+        self.root_dir = os.path.abspath(root_dir)
+        self.config = config
+        self.logger = get_logger(self.__class__.__name__)
+        self.required_dirs = config["audit"]["required_role_dirs"]
+        self.placeholders = config["audit"].get("placeholder_keywords", [])
+        self.report_lines: List[str] = []
+
+    def run(self) -> str:
+        self.logger.info("Starting audit", extra={"root": self.root_dir})
+        self.report_lines.append("## ✅ Valid Items")
+        valid_items: List[str] = []
+        missing_items: List[str] = []
+        placeholders: List[str] = []
+        suggestions: List[str] = []
+
+        roles_dir = os.path.join(self.root_dir, "roles")
+        if not os.path.isdir(roles_dir):
+            self.logger.error("Roles directory missing", extra={"path": roles_dir})
+            self.report_lines.append("## ❌ Missing or Broken")
+            self.report_lines.append(f"- {roles_dir} — Missing directory")
+            report = "\n".join(self.report_lines)
+            report_path = os.path.join(self.root_dir, "validation_report.md")
+            with open(report_path, "w", encoding="utf-8") as f:
+                f.write(report)
+            return report_path
+
+        for role in sorted(os.listdir(roles_dir)):
+            role_path = os.path.join(roles_dir, role)
+            if not os.path.isdir(role_path):
+                continue
+            missing = self._check_role_structure(role_path)
+            if missing:
+                missing_items.extend(missing)
+            self._check_placeholders(role_path, placeholders)
+            self._check_variables(role_path, missing_items, suggestions)
+            valid_items.append(f"roles/{role}")
+
+        self._write_section("## ✅ Valid Items", valid_items)
+        self._write_section("## ❌ Missing or Broken", missing_items)
+        self._write_section("## ⚠️ Placeholders Detected", placeholders)
+        self._write_section("## 🛠 Fix Recommendations", suggestions)
+
+        report = "\n".join(self.report_lines)
+        report_path = os.path.join(self.root_dir, "validation_report.md")
+        with open(report_path, "w", encoding="utf-8") as f:
+            f.write(report)
+        self.logger.info("Report written", extra={"path": report_path})
+        return report_path
+
+    def _write_section(self, header: str, items: List[str]) -> None:
+        self.report_lines.append(header)
+        if items:
+            for item in items:
+                self.report_lines.append(f"- {item}")
+        else:
+            self.report_lines.append("- none")
+        self.report_lines.append("")
+
+    def _check_role_structure(self, role_path: str) -> List[str]:
+        missing: List[str] = []
+        for directory in self.required_dirs:
+            dir_path = os.path.join(role_path, directory)
+            if not os.path.isdir(dir_path):
+                missing.append(f"{role_path}/{directory} — Missing directory")
+        return missing
+
+    def _check_placeholders(self, role_path: str, results: List[str]) -> None:
+        for root, _, files in os.walk(role_path):
+            for fname in files:
+                if not fname.endswith((".yml", ".yaml", ".j2", ".txt", ".md")):
+                    continue
+                fpath = os.path.join(root, fname)
+                try:
+                    with open(fpath, "r", encoding="utf-8") as f:
+                        content = f.read()
+                    for keyword in self.placeholders:
+                        if keyword in content:
+                            results.append(f"{fpath} contains '{keyword}'")
+                except (OSError, UnicodeDecodeError) as exc:
+                    self.logger.warning(
+                        "Failed to read file", extra={"file": fpath, "error": str(exc)}
+                    )
+
+    def _check_variables(
+        self, role_path: str, missing: List[str], suggestions: List[str]
+    ) -> None:
+        variables = self._load_defined_variables(role_path)
+        used_vars = set()
+        for root, _, files in os.walk(os.path.join(role_path, "tasks")):
+            for fname in files:
+                if fname.endswith((".yml", ".yaml")):
+                    fpath = os.path.join(root, fname)
+                    used_vars.update(self._extract_vars(fpath))
+        undefined = used_vars - set(variables.keys())
+        for var in sorted(undefined):
+            missing.append(f"{role_path}: undefined variable '{var}'")
+            suggestions.append(f"Define '{var}' in defaults/main.yml or vars/main.yml")
+
+    def _extract_vars(self, path: str) -> List[str]:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                content = f.read()
+        except OSError as exc:
+            self.logger.warning(
+                "Failed to read", extra={"file": path, "error": str(exc)}
+            )
+            return []
+        return self.VARIABLE_PATTERN.findall(content)
+
+    def _load_defined_variables(self, role_path: str) -> Dict[str, any]:
+        vars_files = [
+            os.path.join(role_path, "defaults", "main.yml"),
+            os.path.join(role_path, "vars", "main.yml"),
+        ]
+        variables: Dict[str, any] = {}
+        for vf in vars_files:
+            if os.path.isfile(vf):
+                try:
+                    with open(vf, "r", encoding="utf-8") as f:
+                        variables.update(yaml.safe_load(f) or {})
+                except yaml.YAMLError as exc:
+                    self.logger.warning(
+                        "Invalid YAML", extra={"file": vf, "error": str(exc)}
+                    )
+        return variables

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,5 @@
+"""API package for AuditAgent."""
+
+from .server import app
+
+__all__ = ["app"]

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -1,0 +1,55 @@
+import os
+import asyncio
+
+from fastapi import Depends, FastAPI, HTTPException, Header
+from fastapi.responses import FileResponse
+import yaml
+
+from agent.audit_agent import AuditAgent
+from utils.logger import get_logger
+from utils.rate_limiter import TokenBucket
+
+app = FastAPI(title="AuditAgent API")
+logger = get_logger("api")
+config: dict | None = None
+rate_limiter: TokenBucket | None = None
+
+
+def get_api_key(x_api_key: str = Header(...)) -> str:
+    expected = os.environ.get("AGENT_API_KEY")
+    if not expected or x_api_key != expected:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    return x_api_key
+
+
+def check_rate_limit() -> None:
+    if rate_limiter and not rate_limiter.consume():
+        raise HTTPException(status_code=429, detail="Too Many Requests")
+
+
+def load_config() -> dict:
+    with open("config/config.yml", "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+@app.on_event("startup")
+def startup() -> None:
+    global config, rate_limiter
+    config = load_config()
+    rl_conf = config.get("rate_limit", {})
+    rate_limiter = TokenBucket(rl_conf.get("max_calls", 5), rl_conf.get("period", 60))
+
+
+@app.post("/audit", dependencies=[Depends(get_api_key), Depends(check_rate_limit)])
+async def run_audit(root: str = "."):
+    agent = AuditAgent(root, config)
+    report = await asyncio.to_thread(agent.run)
+    return {"report": report}
+
+
+@app.get("/report", dependencies=[Depends(get_api_key), Depends(check_rate_limit)])
+async def get_report() -> FileResponse:
+    path = os.path.join(os.getcwd(), "validation_report.md")
+    if not os.path.isfile(path):
+        raise HTTPException(status_code=404, detail="Report not found")
+    return FileResponse(path)

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,32 @@
+import argparse
+import os
+import yaml
+
+from agent.audit_agent import AuditAgent
+from utils.logger import get_logger
+
+
+def load_config(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Audit Ansible Collection")
+    parser.add_argument("command", choices=["run"], help="Command to execute")
+    parser.add_argument("--root", default=".", help="Root directory to scan")
+    parser.add_argument("--config", default="config/config.yml", help="Config file")
+    args = parser.parse_args()
+
+    logger = get_logger("CLI")
+    config = load_config(args.config)
+
+    if args.command == "run":
+        root = os.path.abspath(args.root)
+        agent = AuditAgent(root, config)
+        report_path = agent.run()
+        logger.info("Audit complete", extra={"report": report_path})
+
+
+if __name__ == "__main__":
+    main()

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,7 @@
+"""Utility package for AuditAgent."""
+
+from .logger import get_logger
+from .cache import JsonFileCache
+from .rate_limiter import TokenBucket
+
+__all__ = ["get_logger", "JsonFileCache", "TokenBucket"]

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -1,0 +1,21 @@
+import json
+import os
+from typing import Any, Dict
+
+
+class JsonFileCache:
+    """Simple JSON file cache."""
+
+    def __init__(self, path: str = "cache.json") -> None:
+        self.path = path
+        if not os.path.exists(self.path):
+            with open(self.path, "w", encoding="utf-8") as f:
+                json.dump({}, f)
+
+    def read(self) -> Dict[str, Any]:
+        with open(self.path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def write(self, data: Dict[str, Any]) -> None:
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,0 +1,42 @@
+import json
+import logging
+import os
+import sys
+
+
+class JsonFormatter(logging.Formatter):
+    """Format logs as JSON strings."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_record = {
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+            "time": self.formatTime(record, self.datefmt),
+        }
+        if record.exc_info:
+            log_record["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(log_record)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger with JSON formatter and file handler."""
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+
+    formatter = JsonFormatter()
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    log_dir = os.environ.get("LOG_DIR", "logs")
+    os.makedirs(log_dir, exist_ok=True)
+    file_handler = logging.FileHandler(os.path.join(log_dir, f"{name}.log"))
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    level = os.environ.get("LOG_LEVEL", "INFO")
+    logger.setLevel(level)
+    return logger

--- a/src/utils/rate_limiter.py
+++ b/src/utils/rate_limiter.py
@@ -1,0 +1,23 @@
+import time
+from threading import Lock
+
+
+class TokenBucket:
+    def __init__(self, max_tokens: int, refill_period: int) -> None:
+        self.max_tokens = max_tokens
+        self.tokens = max_tokens
+        self.refill_period = refill_period
+        self.last_refill = time.time()
+        self.lock = Lock()
+
+    def consume(self, tokens: int = 1) -> bool:
+        with self.lock:
+            now = time.time()
+            elapsed = now - self.last_refill
+            if elapsed > self.refill_period:
+                self.tokens = self.max_tokens
+                self.last_refill = now
+            if self.tokens >= tokens:
+                self.tokens -= tokens
+                return True
+            return False

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from agent.audit_agent import AuditAgent
+
+
+def create_role(tmpdir: Path):
+    role_path = tmpdir / "roles" / "sample"
+    (role_path / "tasks").mkdir(parents=True)
+    (role_path / "defaults").mkdir()
+    with open(role_path / "tasks" / "main.yml", "w") as f:
+        f.write("- name: Test\n  debug:\n    msg: '{{ message }}'\n")
+    with open(role_path / "defaults" / "main.yml", "w") as f:
+        yaml.safe_dump({"message": "hello"}, f)
+    return tmpdir
+
+
+def test_agent_generates_report(tmp_path):
+    tmpdir = create_role(tmp_path)
+    config = yaml.safe_load(Path("config/config.yml").read_text())
+    agent = AuditAgent(str(tmpdir), config)
+    report = agent.run()
+    assert Path(report).is_file()
+    content = Path(report).read_text()
+    assert "roles/sample" in content

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,56 @@
+import os
+from pathlib import Path
+
+import yaml
+from fastapi.testclient import TestClient
+
+import api.server as server
+
+
+def setup_module(module):
+    os.environ["AGENT_API_KEY"] = "test"
+    server.startup()
+
+
+def setup_function(function):
+    if server.rate_limiter:
+        server.rate_limiter.tokens = server.rate_limiter.max_tokens
+
+
+def test_audit_endpoint(tmp_path):
+    role = tmp_path / "roles" / "demo"
+    (role / "tasks").mkdir(parents=True)
+    (role / "defaults").mkdir()
+    (role / "tasks" / "main.yml").write_text(
+        "- name: t\n  debug:\n    msg: '{{ msg }}'\n"
+    )
+    (role / "defaults" / "main.yml").write_text(yaml.safe_dump({"msg": "hi"}))
+
+    client = TestClient(server.app)
+    resp = client.post(
+        "/audit", params={"root": str(tmp_path)}, headers={"x-api-key": "test"}
+    )
+    assert resp.status_code == 200
+    report_path = Path(resp.json()["report"])
+    assert report_path.exists()
+
+
+def test_rate_limit(tmp_path):
+    role = tmp_path / "roles" / "demo"
+    (role / "tasks").mkdir(parents=True)
+    (role / "defaults").mkdir()
+    (role / "tasks" / "main.yml").write_text(
+        "- name: t\n  debug:\n    msg: '{{ msg }}'\n"
+    )
+    (role / "defaults" / "main.yml").write_text(yaml.safe_dump({"msg": "hi"}))
+
+    client = TestClient(server.app)
+    for _ in range(5):
+        r = client.post(
+            "/audit", params={"root": str(tmp_path)}, headers={"x-api-key": "test"}
+        )
+        assert r.status_code == 200
+    r = client.post(
+        "/audit", params={"root": str(tmp_path)}, headers={"x-api-key": "test"}
+    )
+    assert r.status_code == 429


### PR DESCRIPTION
## Summary
- add asynchronous API with token bucket rate limiting
- add JSON log file handler and log directory env var
- sanitize root path in CLI
- handle missing roles directory in AuditAgent
- include FastAPI tests for API auth and rate limiting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e1d59193c8333aba05e8fd94b811a